### PR TITLE
if else to fix zero padding bug

### DIFF
--- a/calc_ltsa.m
+++ b/calc_ltsa.m
@@ -146,8 +146,11 @@ for k = 1:PARAMS.ltsa.nxwav            % loop over all xwavs
             if dsz < PARAMS.ltsa.nfft
                 %                 dz = zeros(PARAMS.ltsa.nfft-nsamp,1);
                 dz = zeros(PARAMS.ltsa.nfft-dsz,1);
-                               data = [data,dz'];
-                %  data = [data,dz'];
+                if size(data,1) > 1 % column vector, typical for wav/flac
+                    data = [data;dz]; 
+                elseif size(data,2) > 1 % row vector, typical for xwav
+                    data = [data,dz'];
+                end
                 disp(['File# Raw# Ave# DataSize: ',num2str(k),'  ',num2str(r),'  ',num2str(n),'  ',num2str(dsz)])
                 %                 disp('Paused ... press any key to continue')
                 % pause


### PR DESCRIPTION
xwavs read in data as row vector, wavs read in as column vector, this pads based on size of 'data'

- several pull requests to get `main-sf` to contain all my individual branched updates